### PR TITLE
fix(DocumentDownloader): convert caseId to string for consistent prop…

### DIFF
--- a/src/components/cases/cases-id/DocumentDownloader.tsx
+++ b/src/components/cases/cases-id/DocumentDownloader.tsx
@@ -41,7 +41,7 @@ export default function DocumentDownloader({
       <DocumentsModal 
         isOpen={isModalOpen}
         onClose={handleCloseModal}
-        caseId={caseId}
+        caseId={caseId.toString()}
       />
     </div>
   );


### PR DESCRIPTION
… type

- Update caseId prop in DocumentsModal to ensure it is passed as a string, improving type consistency and preventing potential issues with prop validation.