### PR TITLE
feat(cases): add tab navigation for cases and califications pages

### DIFF
--- a/src/app/dashboard/cases/califications/page.tsx
+++ b/src/app/dashboard/cases/califications/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { Tab, Tabs } from "@heroui/react";
+import { usePathname } from "next/navigation";
 
 const TableCalifications = dynamic(
   () => import("@/components/califications/Table"),
@@ -10,10 +12,19 @@ const TableCalifications = dynamic(
 );
 
 export default function CalificationsPage() {
+  const pathname = usePathname();
   return (
     <>
       <h1 className="semibold-32 text-primary mb-7">Panel de calificaciones</h1>
       <section className="flex flex-col gap-2 pb-8">
+        <Tabs aria-label="Opciones" selectedKey={pathname} className="mb-4">
+          <Tab key="casos" title="Casos" href="/dashboard/cases" />
+          <Tab
+            key="calificaciones"
+            title="Calificaciones"
+            href="/dashboard/cases/califications"
+          />
+        </Tabs>
         <p className="text-[#808080] text-sm">
           Filtra los estudiantes por su caso
         </p>

--- a/src/app/dashboard/cases/page.tsx
+++ b/src/app/dashboard/cases/page.tsx
@@ -1,16 +1,27 @@
 "use client";
 
+import { Tab, Tabs } from "@heroui/react";
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
 
 const TableCases = dynamic(() => import("@/components/cases/Table"), {
   ssr: false,
 });
 
 export default function CasesPage() {
+  const pathname = usePathname();
   return (
     <>
       <h1 className="semibold-32 text-primary mb-7">Casos</h1>
       <section className="flex flex-col gap-2 pb-8">
+        <Tabs aria-label="Opciones" selectedKey={pathname} className="mb-4">
+          <Tab key="casos" title="Casos" href="/dashboard/cases" />
+          <Tab
+            key="calificaciones"
+            title="Calificaciones"
+            href="/dashboard/cases/califications"
+          />
+        </Tabs>
         <p className="text-[#808080] text-sm">
           Filtra los casos por su actual estado
         </p>

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -21,6 +21,7 @@ const pathTranslations: { [key: string]: string } = {
   create: "Crear Ciudadano",
   users: "Usuarios",
   new: "Nuevo",
+  califications: "Calificaciones",
   edit: "Editar",
   view: "Ver",
   reports: "Reportes",


### PR DESCRIPTION
- Implemented tab navigation in CasesPage and CalificationsPage to allow users to switch between "Casos" and "Calificaciones".
- Integrated usePathname to highlight the active tab based on the current URL.
- Updated Header component to include a translation for "Calificaciones" for better user experience.